### PR TITLE
RESTMapper - Start Controller and Webhook on new CRDs availability

### DIFF
--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -67,24 +69,17 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 			if err != nil {
 				return fmt.Errorf("%s: %w: %w", fwkNamePrefix, errFailedMappingResource, err)
 			}
-			if _, err = mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+			if _, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
 				if !meta.IsNoMatchError(err) {
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
+				go waitForAPI(context.Background(), mgr, logger, gvk, func() {
+					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
+					setupControllerAndWebhook(mgr, gvk, fwkNamePrefix, cb, opts...)
+				})
 			} else {
-				if err = cb.NewReconciler(
-					mgr.GetClient(),
-					mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
-					opts...,
-				).SetupWithManager(mgr); err != nil {
-					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
-				}
-				if err = cb.SetupWebhook(mgr, opts...); err != nil {
-					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
-				}
-				logger.Info("Set up controller and webhook for job framework")
-				return nil
+				setupControllerAndWebhook(mgr, gvk, fwkNamePrefix, cb, opts...)
 			}
 		}
 		if err := noop.SetupWebhook(mgr, cb.JobType); err != nil {
@@ -92,6 +87,43 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 		}
 		return nil
 	})
+}
+
+func setupControllerAndWebhook(mgr ctrl.Manager, gvk schema.GroupVersionKind, fwkNamePrefix string, cb IntegrationCallbacks, opts ...Option) error {
+    if err := cb.NewReconciler(
+        mgr.GetClient(),
+        mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", gvk.Kind, "managerName")), // Ensure managerName is defined or fetched
+        opts...,
+    ).SetupWithManager(mgr); err != nil {
+        return fmt.Errorf("%s: %w", fwkNamePrefix, err)
+    }
+
+    if err := cb.SetupWebhook(mgr, opts...); err != nil {
+        return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
+    }
+
+    return nil
+}
+
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+	getRestMapping := func() (*meta.RESTMapping, error) {
+		return mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+	var err error
+	for {
+		_, err = getRestMapping()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				log.Info(fmt.Sprint("Context cancelled!", "gvk", gvk))
+				return
+			case <-time.After(time.Second * 5):
+				continue
+			}
+		}
+		break
+	}
+	action()
 }
 
 // SetupIndexes setups the indexers for integrations.


### PR DESCRIPTION
Add function to wait for API availability using the RESTMapper in controller manager.

This PR checks for availability of JobFramework integrations in the Kubernetes cluster before executing an action.

The function utilises the RESTMapper from the controller-runtime manager to verify the existence of the CRD by its GroupVersionKind (GVK). If one of the CRDs become available, the respective controller and webhook will start.

No restarts on the Kueue pod is performed.