### PR TITLE
Cancel context kueue - No mutex/locks

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -72,8 +71,6 @@ import (
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 	// +kubebuilder:scaffold:imports
 )
-
-const retryInterval = time.Second * 20
 
 var (
 	scheme   = runtime.NewScheme()
@@ -285,7 +282,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 	}
-	if err := jobframework.SetupControllers(ctx, mgr, setupLog, retryInterval, opts...); err != nil {
+	if err := jobframework.SetupControllers(ctx, mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())
 		os.Exit(1)
 	}

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -169,7 +169,7 @@ func main() {
 	cCache := cache.New(mgr.GetClient(), cacheOptions...)
 	queues := queue.NewManager(mgr.GetClient(), cCache, queueOptions...)
 
-	ctx := ctrl.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
 	if err := setupIndexes(ctx, mgr, &cfg); err != nil {
 		setupLog.Error(err, "Unable to setup indexes")
 		os.Exit(1)
@@ -182,7 +182,7 @@ func main() {
 	// Cert won't be ready until manager starts, so start a goroutine here which
 	// will block until the cert is ready before setting up the controllers.
 	// Controllers who register after manager starts will start directly.
-	go setupControllers(ctx, mgr, cCache, queues, certsReady, &cfg, serverVersionFetcher)
+	go setupControllers(ctx, cancel, mgr, cCache, queues, certsReady, &cfg, serverVersionFetcher)
 
 	go queues.CleanUpOnContext(ctx)
 	go cCache.CleanUpOnContext(ctx)
@@ -229,7 +229,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 	return jobframework.SetupIndexes(ctx, mgr.GetFieldIndexer(), opts...)
 }
 
-func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manager, certsReady chan struct{}, cfg *configapi.Configuration, serverVersionFetcher *kubeversion.ServerVersionFetcher) {
+func setupControllers(ctx context.Context, cancel context.CancelFunc, mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manager, certsReady chan struct{}, cfg *configapi.Configuration, serverVersionFetcher *kubeversion.ServerVersionFetcher) {
 	// The controllers won't work until the webhooks are operating, and the webhook won't work until the
 	// certs are all in place.
 	cert.WaitForCertsReady(setupLog, certsReady)
@@ -282,7 +282,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 	}
-	if err := jobframework.SetupControllers(ctx, mgr, setupLog, opts...); err != nil {
+	if err := jobframework.SetupControllers(ctx, cancel, mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())
 		os.Exit(1)
 	}

--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"sync"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +76,6 @@ type integrationManager struct {
 	integrations         map[string]IntegrationCallbacks
 	enabledIntegrations  set.Set[string]
 	externalIntegrations map[string]runtime.Object
-	mu                   sync.RWMutex
 }
 
 var manager integrationManager
@@ -149,15 +147,7 @@ func (m *integrationManager) getExternal(kindArg string) (runtime.Object, bool) 
 	return jt, f
 }
 
-func (m *integrationManager) getEnabledIntegrations() set.Set[string] {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.enabledIntegrations.Clone()
-}
-
 func (m *integrationManager) enableIntegration(name string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.enabledIntegrations == nil {
 		m.enabledIntegrations = set.New(name)
 	} else {
@@ -173,7 +163,7 @@ func (m *integrationManager) getList() []string {
 }
 
 func (m *integrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference) runtime.Object {
-	for jobKey := range m.getEnabledIntegrations() {
+	for jobKey := range m.enabledIntegrations {
 		cbs, found := m.integrations[jobKey]
 		if found && cbs.IsManagingObjectsOwner != nil && cbs.IsManagingObjectsOwner(ownerRef) {
 			return cbs.JobType
@@ -217,14 +207,12 @@ func EnableIntegration(name string) {
 // Mark the frameworks identified by names and return a revert function.
 func EnableIntegrationsForTest(tb testing.TB, names ...string) func() {
 	tb.Helper()
-	old := manager.getEnabledIntegrations()
+	old := manager.enabledIntegrations
 	for _, name := range names {
 		manager.enableIntegration(name)
 	}
 	return func() {
-		manager.mu.Lock()
 		manager.enabledIntegrations = old
-		manager.mu.Unlock()
 	}
 }
 

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -38,7 +38,7 @@ var (
 )
 
 // APIRetryInterval is the duration to wait before retrying the API request.
-const APIRetryInterval = time.Second * 20
+var APIRetryInterval = time.Second * 20
 
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -37,6 +37,9 @@ var (
 	errFailedMappingResource = errors.New("restMapper failed mapping resource")
 )
 
+// APIRetryInterval is the duration to wait before retrying the API request.
+const APIRetryInterval = time.Second * 20
+
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,
 // they can easily setup controllers and webhooks for the in-house custom jobs.
@@ -80,10 +83,14 @@ func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger,
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
 				go waitForAPI(context.Background(), mgr, logger, gvk, func() {
 					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
-					m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
+					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
+						log.Error(err, "Failed to setup controller and webhook for job framework")
+					}
 				})
 			} else {
-				m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
+				if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
+					return err
+				}
 			}
 		}
 		if err := noop.SetupWebhook(mgr, cb.JobType); err != nil {
@@ -109,18 +116,14 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 }
 
 func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
-	getRestMapping := func() (*meta.RESTMapping, error) {
-		return mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
-	}
-	var err error
 	for {
-		_, err = getRestMapping()
+		_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
 			select {
 			case <-ctx.Done():
 				log.Info(fmt.Sprint("Context cancelled!", "gvk", gvk))
 				return
-			case <-time.After(time.Second * 5):
+			case <-time.After(APIRetryInterval):
 				continue
 			}
 		}

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,12 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -34,10 +34,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
 )
 
+type checkAPIAvailableFunc func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error)
+
 var (
 	errFailedMappingResource = errors.New("restMapper failed mapping resource")
-	// restMapperMutex is required for unit tests to lock the RESTMapper on update.
-	restMapperMutex sync.RWMutex
 )
 
 // SetupControllers setups all controllers and webhooks for integrations.
@@ -49,11 +49,11 @@ var (
 // this function needs to be called after the certs get ready because the controllers won't work
 // until the webhooks are operating, and the webhook won't work until the
 // certs are all in place.
-func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
-	return manager.setupControllers(ctx, mgr, log, retryInterval, opts...)
+func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+	return manager.setupControllers(ctx, mgr, log, opts...)
 }
 
-func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
+func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
 	for fwkName := range options.EnabledExternalFrameworks {
@@ -81,7 +81,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
-				go waitForAPI(ctx, mgr, log, gvk, retryInterval, func() {
+				go waitForAPI(ctx, mgr, defaultCheckAPIAvailable, log, gvk, func() {
 					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
 					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller and webhook for job framework")
@@ -115,35 +115,43 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, retryInterval time.Duration, action func()) {
-	ticker := time.NewTicker(retryInterval)
-	defer ticker.Stop()
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, checkAPIAvailable checkAPIAvailableFunc, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(100*time.Millisecond, 100*time.Second)
+	item := gvk.String()
+
 	for {
-		_, err := getRESTMapping(mgr, gvk)
-		if err == nil {
+		isAvailable, err := checkAPIAvailable(mgr, gvk)
+		if isAvailable {
+			rateLimiter.Forget(item)
 			action()
 			return
 		}
-		if !meta.IsNoMatchError(err) {
+		if err != nil && !meta.IsNoMatchError(err) {
 			log.Error(err, "Failed to get REST mapping for gvk", "gvk", gvk)
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(rateLimiter.When(item)):
 			continue
 		}
 	}
 }
 
 func getRESTMapping(mgr ctrl.Manager, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
-	restMapperMutex.RLock()
-	defer restMapperMutex.RUnlock()
 	restMapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
 	}
 	return restMapping, nil
+}
+
+var defaultCheckAPIAvailable checkAPIAvailableFunc = func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error) {
+	_, err := getRESTMapping(mgr, gvk)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // SetupIndexes setups the indexers for integrations.

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -39,11 +39,19 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	kslices "sigs.k8s.io/kueue/pkg/util/slices"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func TestSetupControllers(t *testing.T) {
+	// Simulate Job Framework API checks
+	defaultCheckAPIAvailable = func(mgr ctrlmgr.Manager, gvk schema.GroupVersionKind) (bool, error) {
+		// Simulate API being unavailable for MPIJob
+		if gvk.Kind == "MPIJob" {
+			return false, nil
+		}
+		return true, nil // Simulate API becoming available
+	}
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -124,7 +132,7 @@ func TestSetupControllers(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			manager := &integrationManager{}
+			manager := integrationManager{}
 			for name, cbs := range availableIntegrations {
 				err := manager.register(name, cbs)
 				if err != nil {
@@ -157,13 +165,13 @@ func TestSetupControllers(t *testing.T) {
 				t.Fatalf("Failed to setup manager: %v", err)
 			}
 
-			gotError := manager.setupControllers(context.Background(), mgr, logger, time.Millisecond*20, tc.opts...)
+			gotError := manager.setupControllers(context.Background(), mgr, logger, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
 			}
 
 			if tc.afterSetup != nil {
-				tc.afterSetup(mgr, manager)
+				tc.afterSetup(mgr, &manager)
 			}
 
 			diff := cmp.Diff(tc.wantEnabledIntegrations, manager.getEnabledIntegrations().SortedList())
@@ -175,11 +183,6 @@ func TestSetupControllers(t *testing.T) {
 }
 
 func testDelayedIntegration(mgr ctrlmgr.Manager, manager *integrationManager) {
-	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
-	restMapperMutex.Lock()
-	mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
-	restMapperMutex.Unlock()
-	// Wait for setup to complete
 	for {
 		_, ok := manager.getEnabledIntegrations()["ray.io/raycluster"]
 		if ok {
@@ -253,8 +256,8 @@ func TestSetupIndexes(t *testing.T) {
 			if gotListErr := k8sClient.List(ctx, gotWls, client.InNamespace(testNamespace)); gotListErr != nil {
 				t.Fatalf("Failed to list workloads without a fieldMatcher: %v", gotListErr)
 			}
-			deployedWlNames := kslices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
-			gotWlNames := kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+			deployedWlNames := slices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
+			gotWlNames := slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 			if diff := cmp.Diff(deployedWlNames, gotWlNames, cmpopts.EquateEmpty(),
 				cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 				t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)
@@ -267,7 +270,7 @@ func TestSetupIndexes(t *testing.T) {
 			}
 
 			if !tc.wantFieldMatcherError {
-				gotWlNames = kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+				gotWlNames = slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 				if diff := cmp.Diff(tc.wantWorkloads, gotWlNames, cmpopts.EquateEmpty(),
 					cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 					t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)


### PR DESCRIPTION
Tests are passing. 

The use of mutexes/locks is not required here.

The context is cancelled once a newly available Framework is found, causing the Kueue pod to restart.

This is a more robust solution as all processes start from a fresh state, which would start the controllers and webhooks of the newly added CRDs.